### PR TITLE
docs: add OpenAI semantic processing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ aspects:
 airflow dags trigger sailboat_semantic_processing
 ```
 
+#### Semantic processing with OpenAI
+
+Use the OpenAI API for embeddings without downloading any local model:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+airflow dags trigger sailboat_semantic_processing
+```
+
+When `OPENAI_API_KEY` is set and no local `sentence-transformers` model is
+available, the DAG generates embeddings via OpenAI and skips local model
+downloads.
+
 ## Tests
 
 Run the semantic search test script which exercises chunking, embeddings and


### PR DESCRIPTION
## Summary
- document how to set `OPENAI_API_KEY`
- explain triggering `sailboat_semantic_processing` with OpenAI so no model download occurs

## Testing
- `python scripts/test_semantic_search.py` *(fails: OpenAI API key required)*

------
https://chatgpt.com/codex/tasks/task_e_68c04b848fb0833399cac236054cd4af