### PR TITLE
Extract equipment list from FINN items

### DIFF
--- a/scraper/parse_item.py
+++ b/scraper/parse_item.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from bs4 import BeautifulSoup
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, List
 from urllib.parse import unquote, urlparse, parse_qs
 import json
 import logging
@@ -155,6 +155,47 @@ def _extract_from_data_props(soup: BeautifulSoup) -> Dict[str, Any]:
     elif isinstance(price, (int, float)):
         data['price'] = int(price)
         data['currency'] = 'NOK'
+
+    # Utstyr/Equipment-listen kan ligge dypt inne i data-props. Gå rekursivt
+    equipment: List[str] = []
+
+    def _collect_items(val: Any) -> List[str]:
+        items: List[str] = []
+        if isinstance(val, list):
+            for it in val:
+                if isinstance(it, str):
+                    txt = it.strip()
+                    if txt:
+                        items.append(txt)
+                elif isinstance(it, dict):
+                    for k in ('label', 'title', 'value', 'name', 'text'):
+                        v = it.get(k)
+                        if isinstance(v, str) and v.strip():
+                            items.append(v.strip())
+                            break
+        return items
+
+    def _scan(node: Any) -> None:
+        if isinstance(node, dict):
+            heading = None
+            for key in ('heading', 'title', 'label', 'name', 'text'):
+                val = node.get(key)
+                if isinstance(val, str):
+                    heading = val.strip()
+                    break
+            if heading and heading.lower() == 'utstyr':
+                for key in ('items', 'value', 'values', 'list', 'children'):
+                    maybe = node.get(key)
+                    equipment.extend(_collect_items(maybe))
+            for v in node.values():
+                _scan(v)
+        elif isinstance(node, list):
+            for v in node:
+                _scan(v)
+
+    _scan(dp_obj)
+    if equipment:
+        data['equipment'] = equipment
 
     return data
 
@@ -449,6 +490,29 @@ def _extract_from_dom_fallback(soup: BeautifulSoup) -> Dict[str, Any]:
                         data['currency'] = 'NOK'
                     except Exception:
                         pass
+
+    # Finn seksjon med overskrift "Utstyr" og hent alle bullet points
+    for h2 in soup.find_all('h2'):
+        heading = _text(h2)
+        if heading and heading.strip().lower() == 'utstyr':
+            section = h2.find_parent('section')
+            container = None
+            if section:
+                container = section.find('ul') or section
+            if not container:
+                sib = h2.find_next_sibling()
+                while sib and not sib.find_all('li'):
+                    sib = sib.find_next_sibling()
+                container = sib
+            items: List[str] = []
+            if container:
+                for li in container.find_all('li'):
+                    txt = li.get_text(' ', strip=True)
+                    if txt:
+                        items.append(txt)
+            if items:
+                data['equipment'] = items
+            break
 
     # Oversikts-grid: label (p eller label) med klasse s-text-subtle + verdi i p.font-bold
     label_nodes = soup.select('label.s-text-subtle, p.s-text-subtle')
@@ -819,6 +883,7 @@ def fetch_and_parse_item(ad_url: str) -> Optional[Tuple[Dict[str, Any], Dict[str
         if not parsed:
             return None
         normalized, source = parsed
+        normalized.setdefault('equipment', [])
 
         # Hvis ingen informative felter, forsøk browser-fallback én gang
         if not _has_informative_fields(normalized):
@@ -828,6 +893,7 @@ def fetch_and_parse_item(ad_url: str) -> Optional[Tuple[Dict[str, Any], Dict[str
                 parsed2 = parse_item_html(bhtml)
                 if parsed2:
                     normalized2, source2 = parsed2
+                    normalized2.setdefault('equipment', [])
                     if _has_informative_fields(normalized2):
                         normalized, source = normalized2, source2
 

--- a/scripts/test_equipment_scraper.py
+++ b/scripts/test_equipment_scraper.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Testscript for å verifisere at scraperen trekker ut utstyrsliste
+fra FINN-annonser. Bruker samme fetch-logikk som hovedscraperen for å
+unngå blokkering. Skriptet henter en eller flere URLer og skriver ut alle
+utstyrsposter samt om "ccs" finnes i listen.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from typing import List
+
+# Sørg for import fra prosjektroten
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(CURRENT_DIR)
+if PROJECT_ROOT not in sys.path:
+    sys.path.append(PROJECT_ROOT)
+
+from scraper.scrape_boats import fetch_html  # type: ignore
+from scraper.parse_item import parse_item_html  # type: ignore
+
+
+def check_equipment(url: str) -> None:
+    """Hent annonse og skriv ut utstyrsliste."""
+    logging.info("Henter %s", url)
+    html = fetch_html(url)
+    if not html:
+        print(f"Kunne ikke hente eller parse: {url}")
+        return
+    parsed = parse_item_html(html)
+    if not parsed:
+        print(f"Kunne ikke parse HTML for: {url}")
+        return
+    normalized, _ = parsed
+    equipment: List[str] = [str(it) for it in normalized.get("equipment", [])]
+    print(f"\nUtstyrsliste for {url} ({len(equipment)}):")
+    for item in equipment:
+        print(f" - {item}")
+    has_ccs = any("ccs" in item.lower() for item in equipment)
+    print(f"Har CCS? {has_ccs}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Test-uttrekk av 'Utstyr' fra FINN-annonser"
+    )
+    parser.add_argument(
+        "urls", nargs="*", help="En eller flere FINN item-URLer", default=[]
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    urls = args.urls or ["https://www.finn.no/mobility/item/59906244"]
+    for url in urls:
+        check_equipment(url)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- parse data-props and DOM fallbacks to capture "Utstyr" lists as `equipment`
- ensure `fetch_and_parse_item` always returns an `equipment` list
- add test script using scraper's fetch logic to inspect equipment

## Testing
- `python -m py_compile scraper/parse_item.py scripts/test_equipment_scraper.py`
- `python scripts/test_equipment_scraper.py` *(fails: HTTPSConnectionPool(host='www.finn.no', port=443): Max retries exceeded with url: /mobility/item/59906244 (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_68c075a696e48333a5ba8abde12033bb