### PR TITLE
Handle nested and HTML equipment lists

### DIFF
--- a/scraper/parse_item.py
+++ b/scraper/parse_item.py
@@ -161,18 +161,25 @@ def _extract_from_data_props(soup: BeautifulSoup) -> Dict[str, Any]:
 
     def _collect_items(val: Any) -> List[str]:
         items: List[str] = []
-        if isinstance(val, list):
+        if isinstance(val, str):
+            txt = val.strip()
+            if txt:
+                items.append(txt)
+        elif isinstance(val, list):
             for it in val:
-                if isinstance(it, str):
-                    txt = it.strip()
-                    if txt:
-                        items.append(txt)
-                elif isinstance(it, dict):
-                    for k in ('label', 'title', 'value', 'name', 'text'):
-                        v = it.get(k)
-                        if isinstance(v, str) and v.strip():
-                            items.append(v.strip())
-                            break
+                items.extend(_collect_items(it))
+        elif isinstance(val, dict):
+            nested: List[str] = []
+            for key in ('items', 'value', 'values', 'list', 'children'):
+                nested.extend(_collect_items(val.get(key)))
+            if nested:
+                items.extend(nested)
+            else:
+                for k in ('label', 'title', 'value', 'name', 'text'):
+                    v = val.get(k)
+                    if isinstance(v, str) and v.strip():
+                        items.append(v.strip())
+                        break
         return items
 
     def _scan(node: Any) -> None:
@@ -194,6 +201,20 @@ def _extract_from_data_props(soup: BeautifulSoup) -> Dict[str, Any]:
                 _scan(v)
 
     _scan(dp_obj)
+    if not equipment:
+        # Se etter enklere equipment-felt hvis vi ikke fant noe ved skanning
+        for key in ('equipment', 'equipment_safe', 'equipment_unsafe'):
+            raw = ad.get(key) or dp_obj.get(key)
+            if isinstance(raw, list):
+                equipment.extend(_collect_items(raw))
+            elif isinstance(raw, str):
+                eq_soup = BeautifulSoup(raw, 'html.parser')
+                for tag in eq_soup.find_all(['li', 'p']):
+                    txt = tag.get_text(strip=True)
+                    if txt:
+                        equipment.append(txt)
+            if equipment:
+                break
     if equipment:
         data['equipment'] = equipment
 


### PR DESCRIPTION
## Summary
- descend into nested equipment lists before adding string labels
- parse `equipment_unsafe` HTML when structured lists are absent

## Testing
- `python -m py_compile scraper/parse_item.py scripts/test_equipment_scraper.py`
- `python scripts/test_equipment_scraper.py` *(fails: HTTPSConnectionPool(host='www.finn.no', port=443): Max retries exceeded with url: /mobility/item/59906244 (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_68c0859c24848333a61d371699c23128