### PR TITLE
fix(ci): repair deploy heredoc indentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,6 @@ jobs:
           REPO_NAME=$(echo "${REPOSITORY#*/}" | tr '[:upper:]' '[:lower:]')
 
           compose_config=$(docker compose config --format json)
-          project=$(echo "$compose_config" | jq -r '.name')
           services=$(echo "$compose_config" | jq -r '.services | to_entries[] | select(.value.build != null) | .key')
 
           if [ -z "$services" ]; then
@@ -108,7 +107,7 @@ jobs:
           services_b64=$(printf '%s' "$services" | base64 | tr -d '\n')
 
           ssh "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" 'bash -s' -- \
-            "${REGISTRY}" "${OWNER}" "${REPO_NAME}" "${project}" "${services_b64}" \
+            "${REGISTRY}" "${OWNER}" "${REPO_NAME}" "${services_b64}" \
             "${{ secrets.DEPLOY_DIRECTORY }}" "${{ secrets.GHCR_TOKEN }}" "${{ secrets.POSTGRES_PASSWORD }}" \
             "${{ secrets.AIRFLOW_FERNET_KEY }}" "${{ secrets.AIRFLOW_SECRET_KEY }}" <<'REMOTE'
             set -euo pipefail
@@ -116,18 +115,20 @@ jobs:
             REGISTRY="$1"
             OWNER="$2"
             REPO_NAME="$3"
-            PROJECT="$4"
-            SERVICES_B64="$5"
-            DEPLOY_DIRECTORY="$6"
-            GHCR_TOKEN="$7"
-            POSTGRES_PASSWORD="$8"
-            AIRFLOW_FERNET_KEY="$9"
-            AIRFLOW_SECRET_KEY="${10}"
+            SERVICES_B64="$4"
+            DEPLOY_DIRECTORY="$5"
+            GHCR_TOKEN="$6"
+            POSTGRES_PASSWORD="$7"
+            AIRFLOW_FERNET_KEY="$8"
+            AIRFLOW_SECRET_KEY="$9"
 
             cd "${DEPLOY_DIRECTORY}"
 
             git fetch origin
             git reset --hard origin/main
+
+            compose_config=$(docker compose config --format json)
+            PROJECT=$(echo "$compose_config" | jq -r '.name')
 
             {
               echo "GHCR_TOKEN=${GHCR_TOKEN}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,159 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  COMPOSE_FILE: docker-compose.yml
+
+jobs:
+  build-and-push:
+    name: Build and push images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push per-service images
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          OWNER=$(echo "${OWNER}" | tr '[:upper:]' '[:lower:]')
+          REPO_NAME=$(echo "${REPOSITORY#*/}" | tr '[:upper:]' '[:lower:]')
+
+          compose_config=$(docker compose config --format json)
+          project=$(echo "$compose_config" | jq -r '.name')
+
+          echo "Detected compose project: $project"
+
+          services=$(echo "$compose_config" | jq -r '.services | to_entries[] | select(.value.build != null) | .key')
+
+          if [ -z "$services" ]; then
+            echo "No services with build directives were found."
+            exit 1
+          fi
+
+          for service in $services; do
+            local_image="${project}-${service}"
+            remote_image="${REGISTRY}/${OWNER}/${REPO_NAME}-${service}:latest"
+
+            echo "Building $service"
+            docker compose build "$service"
+
+            echo "Tagging $local_image as $remote_image"
+            docker tag "$local_image" "$remote_image"
+
+            echo "Pushing $remote_image"
+            docker push "$remote_image"
+          done
+
+  deploy:
+    name: Deploy to server
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create SSH key
+        run: |
+          install -m 600 -D /dev/null ~/.ssh/id_rsa
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+
+      - name: Add host to known_hosts
+        run: |
+          ssh-keyscan -H "${{ secrets.SSH_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy application
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          OWNER=$(echo "${OWNER}" | tr '[:upper:]' '[:lower:]')
+          REPO_NAME=$(echo "${REPOSITORY#*/}" | tr '[:upper:]' '[:lower:]')
+
+          compose_config=$(docker compose config --format json)
+          project=$(echo "$compose_config" | jq -r '.name')
+          services=$(echo "$compose_config" | jq -r '.services | to_entries[] | select(.value.build != null) | .key')
+
+          if [ -z "$services" ]; then
+            echo "No services with build directives were found."
+            exit 1
+          fi
+
+          services_b64=$(printf '%s' "$services" | base64 | tr -d '\n')
+
+          ssh "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" 'bash -s' -- \
+            "${REGISTRY}" "${OWNER}" "${REPO_NAME}" "${project}" "${services_b64}" \
+            "${{ secrets.DEPLOY_DIRECTORY }}" "${{ secrets.GHCR_TOKEN }}" "${{ secrets.POSTGRES_PASSWORD }}" \
+            "${{ secrets.AIRFLOW_FERNET_KEY }}" "${{ secrets.AIRFLOW_SECRET_KEY }}" <<'REMOTE'
+            set -euo pipefail
+
+            REGISTRY="$1"
+            OWNER="$2"
+            REPO_NAME="$3"
+            PROJECT="$4"
+            SERVICES_B64="$5"
+            DEPLOY_DIRECTORY="$6"
+            GHCR_TOKEN="$7"
+            POSTGRES_PASSWORD="$8"
+            AIRFLOW_FERNET_KEY="$9"
+            AIRFLOW_SECRET_KEY="${10}"
+
+            cd "${DEPLOY_DIRECTORY}"
+
+            git fetch origin
+            git reset --hard origin/main
+
+            {
+              echo "GHCR_TOKEN=${GHCR_TOKEN}"
+              echo "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
+              echo "AIRFLOW_FERNET_KEY=${AIRFLOW_FERNET_KEY}"
+              echo "AIRFLOW_SECRET_KEY=${AIRFLOW_SECRET_KEY}"
+            } > .env
+
+            echo "Logging in to GHCR"
+            printf '%s' "${GHCR_TOKEN}" | docker login "${REGISTRY}" -u "${OWNER}" --password-stdin
+
+            services=$(printf '%s' "${SERVICES_B64}" | base64 -d)
+
+            for service in ${services}; do
+              remote_image="${REGISTRY}/${OWNER}/${REPO_NAME}-${service}:latest"
+              local_image="${PROJECT}-${service}:latest"
+
+              echo "Pulling $remote_image"
+              docker pull "$remote_image"
+              docker tag "$remote_image" "$local_image"
+            done
+
+            docker compose up -d
+            docker image prune -f
+          REMOTE
+
+      - name: Clean up SSH key
+        if: ${{ always() }}
+        run: rm -f ~/.ssh/id_rsa


### PR DESCRIPTION
## Summary
- build each Docker Compose service image individually and push it to GHCR with a service-specific tag
- adjust the deploy job to pull the published service images over SSH, retag them for Compose, and then restart the stack
- fix the SSH heredoc delimiter indentation so the workflow YAML parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc2a2554c8333b6736a67d78bd4c2